### PR TITLE
Add option to render rgb and depth for undistorted dslr frames.

### DIFF
--- a/common/configs/render.yml
+++ b/common/configs/render.yml
@@ -6,6 +6,9 @@ render_iphone: True
 # Set True to render depth for dslr frames
 render_dslr: False
 
+# Set True to render depth for undistorted frames (dslr only)
+# render_undistorted: True
+
 splits: [nvs_sem_train, nvs_sem_val]
 
 # Specify scene ids if you want to render depth for specific scenes

--- a/common/render.py
+++ b/common/render.py
@@ -1,4 +1,5 @@
 import argparse
+import json
 import os
 import sys
 from pathlib import Path
@@ -12,7 +13,7 @@ except ImportError:
     print("renderpy not installed. Please install renderpy from https://github.com/liu115/renderpy")
     sys.exit(1)
 
-from common.utils.colmap import read_model, write_model, Image
+from common.utils.colmap import read_model, write_model, Camera, Image
 from common.scene_release import ScannetppScene_Release
 from common.utils.utils import run_command, load_yaml_munch, load_json, read_txt_list
 
@@ -49,6 +50,18 @@ def main(args):
         for device in render_devices:
             if device == "dslr":
                 cameras, images, points3D = read_model(scene.dslr_colmap_dir, ".txt")
+                if cfg.get("render_undistorted", False):
+                    transform_path = scene.dslr_nerfstudio_undistorted_transform_path
+                    with open(transform_path, "r") as f:
+                        transform = json.load(f)
+                    camera = Camera(
+                        id=-1,
+                        model=transform["camera_model"],
+                        width=transform["w"],
+                        height=transform["h"],
+                        params=np.array([transform["fl_x"], transform["fl_y"], transform["cx"], transform["cy"]]),
+                    )
+                    cameras = {camera.id: camera}
             else:
                 cameras, images, points3D = read_model(scene.iphone_colmap_dir, ".txt")
             assert len(cameras) == 1, "Multiple cameras not supported"
@@ -66,8 +79,9 @@ def main(args):
 
             near = cfg.get("near", 0.05)
             far = cfg.get("far", 20.0)
-            rgb_dir = Path(cfg.output_dir) / scene_id / device / "render_rgb"
-            depth_dir = Path(cfg.output_dir) / scene_id / device / "render_depth"
+            suffix = "_undistorted" if cfg.get("render_undistorted", False) else ""
+            rgb_dir = Path(cfg.output_dir) / scene_id / device / f"render_rgb{suffix}"
+            depth_dir = Path(cfg.output_dir) / scene_id / device / f"render_depth{suffix}"
             rgb_dir.mkdir(parents=True, exist_ok=True)
             depth_dir.mkdir(parents=True, exist_ok=True)
             for image_id, image in tqdm(images.items(), f"Rendering {device} images"):

--- a/common/scene_release.py
+++ b/common/scene_release.py
@@ -119,6 +119,10 @@ class ScannetppScene_Release:
     @property
     def dslr_nerfstudio_transform_path(self):
         return self.dslr_dir / 'nerfstudio' / 'transforms.json'
+
+    @property
+    def dslr_nerfstudio_undistorted_transform_path(self):
+        return self.dslr_dir / 'nerfstudio' / 'transforms_undistorted.json'
     
     @property
     def dslr_train_test_lists_path(self):


### PR DESCRIPTION
The script common/render.py renders RGB and depth frames with the DSLR fisheye camera. This PR adds an option to use the undistorted pinhole camera, creating images matching those in "undistorted_images" (generated by dslr/undistort.py).