### PR TITLE
Fix iphone batch rasterization error

### DIFF
--- a/semantic/prep/rasterize.py
+++ b/semantic/prep/rasterize.py
@@ -115,7 +115,7 @@ def main(cfg : DictConfig) -> None:
                 cameras_batch = get_fisheye_cameras_batch(batch_poses, img_height, img_width, intrinsic_mat, distort_params)
             elif cfg.image_type == 'iphone':
                 # opencv cameras
-                cameras_batch = get_opencv_cameras_batch(poses, img_height, img_width, intrinsic_mat)
+                cameras_batch = get_opencv_cameras_batch(batch_poses, img_height, img_width, intrinsic_mat)
 
             bsize = len(batch_image_list)
 


### PR DESCRIPTION
Hi, I found an error when rasterizing 3D Meshes onto 2D Images. (image_type: iphone)
Without using `batch_poses`, the length of `meshes_batch` and `cameras_batch` will not match.
Could you please verify if this is indeed an issue? Thanks!